### PR TITLE
Simplify Wi-Fi connected status message

### DIFF
--- a/freenove.ino
+++ b/freenove.ino
@@ -175,7 +175,7 @@ void connectToWifi() {
     Serial.print("Connected. IP address: ");
     Serial.println(WiFi.localIP());
     wifiConnected = true;
-    wifiStatusMessage = String("Connected (IP: ") + WiFi.localIP().toString() + ")";
+    wifiStatusMessage = String("Connected ") + WiFi.localIP().toString();
   } else {
     Serial.println("WiFi connection timed out.");
     wifiConnected = false;


### PR DESCRIPTION
## Summary
- trim the Wi-Fi connected status text so the display no longer shows "(IP: )"

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d050d401a883269919de293459309b